### PR TITLE
Extra consumption method that allows commits for dropped messages

### DIFF
--- a/src/main/scala/com/ovoenergy/fs2/kafka/package.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/package.scala
@@ -1,3 +1,8 @@
 package com.ovoenergy.fs2
 
-package object kafka extends Consuming with Producing
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+
+package object kafka extends Consuming with Producing {
+  type Offsets = Map[TopicPartition, OffsetAndMetadata]
+}


### PR DESCRIPTION
Added method to Consuming to make it easier to commit a message if it is being dropped. E.g. when `O` in `consumeProcessAndCommit` is an option and the result of `processRecord` is an `Option` and no result is being created.



TODO:
- [ ] tests
- [ ] batch method