### PR TITLE
Added consume method to be able to use with fs2.Pipe

### DIFF
--- a/src/main/scala/com/ovoenergy/fs2/kafka/BatchProcessed.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/BatchProcessed.scala
@@ -1,0 +1,3 @@
+package com.ovoenergy.fs2.kafka
+
+case object BatchProcessed

--- a/src/main/tut/README.md
+++ b/src/main/tut/README.md
@@ -81,6 +81,43 @@ val ints = consumeProcessAndCommit[IO](
 The record processing order is guaranteed within the same partition, while records from different partitions are processed
 in parallel up to the parallelism set into the `ConsumerSettings`.
 
+To consume batch of records, and process records with fs2.Pipe then commit:
+```tut:silent
+import com.ovoenergy.fs2.kafka._
+import scala.concurrent.duration._
+import org.apache.kafka.common.serialization._
+import org.apache.kafka.clients.consumer._
+import cats.effect.IO
+import fs2.Pipe
+
+val settings = ConsumerSettings(
+    pollTimeout = 250.milliseconds,
+    maxParallelism = 4,
+    nativeSettings = Map(
+      ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> "false",
+      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:9092",
+      ConsumerConfig.GROUP_ID_CONFIG -> "my-group-id",
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "earliest"
+    )
+)
+
+val pipe: Pipe[IO, ConsumerRecord[K, V], BatchProcessed.type] = {
+      _.evalMap(c => IO(c.offset()))
+          .filter(_ % 10 == 0)
+          .evalMap(o => IO(println(o)))
+          .drain
+          .asInstanceOf[Stream[IO, BatchProcessed.type]] ++ Stream
+          .eval(IO(BatchProcessed)))
+}
+
+consumeProcessBatchWithPipeAndCommit[IO](
+    TopicSubscription(Set("my-topic")),
+    new StringDeserializer,
+    new StringDeserializer,
+    settings
+)(pipe).take(1).compile.drain.unsafeRunSync()
+```
+
 ## Producing
 The producer is available as effectfull function:
 


### PR DESCRIPTION
processBatchWithPipeAndCommit expect a fs2.Pipe[F[_], ConsumerRecord[K, V], BatchProcessed.type] function. When the ConsumerRecord stream was processed the pipe should return with BatchProcessed. The pipe should handle error. When the pipe returns BatchProcessed the last offset of the batch will be committed to the kafka.

With this method fs2 can be used directly to process the batch items without any extra magic.
See tut and test example