### PR TITLE
Add batch aware producer

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4"
 
   object fs2 {
-    private val version = "0.10.1"
+    private val version = "0.10.5"
 
     lazy val core = "co.fs2" %% "fs2-core" % version
     lazy val io = "co.fs2" %% "fs2-io" % version

--- a/src/main/scala/com/ovoenergy/fs2/kafka/Consuming.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/Consuming.scala
@@ -253,7 +253,7 @@ object Consuming {
       .fold(BatchResults.empty[O])(_ :+ _)
       .evalMap { batchResults =>
         commit[F](consumer, batchResults.toCommit)
-          .map(_ => batchResults.results)
+          .as(batchResults.results)
       }
       .flatMap(Stream.emits(_))
   }
@@ -287,7 +287,7 @@ object Consuming {
       .fold(BatchResults.empty[O])(_ :+ _)
       .evalMap { batchResults =>
         commit[F](consumer, batchResults.toCommit)
-          .map(_ => batchResults)
+          .as(batchResults)
       }
   }
 
@@ -318,7 +318,7 @@ object Consuming {
       .fold(BatchResults.empty[O])(_ :+ _)
       .evalMap { batchResults =>
         commit[F](consumer, batchResults.toCommit)
-          .map(_ => batchResults.results)
+          .as(batchResults.results)
       }
       .flatMap(Stream.emits(_))
   }

--- a/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
@@ -1,14 +1,16 @@
 package com.ovoenergy.fs2.kafka
 
-import cats.effect.{Async, Sync}
+import cats.effect.{Async, Effect, IO, Sync}
 import cats.syntax.traverse._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import com.ovoenergy.fs2.kafka.Producing._
 import fs2._
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.serialization.Serializer
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{ExecutionContext, Promise}
+import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 /**
@@ -33,6 +35,17 @@ trait Producing {
     */
   def produceRecord[F[_]]: ProduceRecordPartiallyApplied[F] =
     new ProduceRecordPartiallyApplied[F]
+
+  /**
+    * Sends a ProducerRecord[K,V] to Kafka. It returns an F[F[RecordMetadata]], the outer F represent the effect to put
+    * the record in the batch. The inner F represent the effect to send the record to Kafka broker.
+    *
+    * The reason for that is allow the Kafka producer to optimize the network communication by sending records in
+    * batches instead of one record at time.
+    */
+  def produceRecordWithBatching[F[_]]
+    : ProduceRecordWithBatchingPartiallyApplied[F] =
+    new ProduceRecordWithBatchingPartiallyApplied[F]()
 
   /**
     * Processes a `Chunk[(ProducerRecord[K, V], P)]`, sending the records to Kafka
@@ -106,6 +119,49 @@ object Producing {
     }
   }
 
+  private[kafka] final class ProduceRecordWithBatchingPartiallyApplied[F[_]](
+      val dummy: Boolean = true)
+      extends AnyVal {
+    def apply[K, V](producer: Producer[K, V], record: ProducerRecord[K, V])(
+        implicit F: Effect[F],
+        ec: ExecutionContext): F[F[RecordMetadata]] = {
+
+      fs2.async.promise[F, Either[Throwable, RecordMetadata]].flatMap {
+        promise =>
+          Effect[F]
+            .delay(producer.send(
+              record,
+              new Callback {
+                override def onCompletion(metadata: RecordMetadata,
+                                          exception: Exception): Unit = {
+                  Option(exception) match {
+                    case Some(e) =>
+                      Effect[F]
+                        .runAsync(promise.complete(Left(e))) {
+                          case Left(e)  => IO.raiseError(e)
+                          case Right(_) => IO(())
+                        }
+                        .unsafeRunSync()
+                    case None =>
+                      Effect[F]
+                        .runAsync(promise.complete(Right(metadata))) {
+                          case Left(e)  => IO.raiseError(e)
+                          case Right(_) => IO(())
+                        }
+                        .unsafeRunSync()
+                  }
+                }
+              }
+            ))
+            .map(_ =>
+              promise.get.flatMap {
+                case Left(e)   => Effect[F].raiseError(e)
+                case Right(rm) => Effect[F].pure(rm)
+            })
+      }
+    }
+  }
+
   private[kafka] final class ProduceRecordBatchPartiallyApplied[F[_]](
       val dummy: Boolean = true)
       extends AnyVal {
@@ -116,7 +172,7 @@ object Producing {
       F.flatten(F.delay {
         recordBatch.traverse {
           case (record, p) =>
-            val promise = Promise[(RecordMetadata, P)]()
+            val promise = scala.concurrent.Promise[(RecordMetadata, P)]()
 
             producer.send(
               record,

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -19,6 +19,7 @@
 
     <!--<logger name="com.ovoenergy.comms.audit" level="DEBUG" />-->
 
+    <!--<logger name="org.apache.kafka.clients.producer" level="TRACE" />-->
 
     <root level="OFF">
         <appender-ref ref="CONSOLE"/>

--- a/src/test/scala/com/ovoenergy/fs2/kafka/KafkaSpec.scala
+++ b/src/test/scala/com/ovoenergy/fs2/kafka/KafkaSpec.scala
@@ -4,7 +4,7 @@ import java.util
 
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import cats.effect.IO
-import fs2.Chunk
+import fs2._
 import org.apache.kafka.clients.consumer.{
   ConsumerConfig,
   ConsumerRecord,
@@ -425,6 +425,55 @@ class KafkaSpec extends BaseUnitSpec with EmbeddedKafka {
         messages should contain theSameElementsAs produced
       }
 
+    }
+  }
+
+  "produceRecordWithBatching" should {
+    "batch" in withRunningKafkaOnFoundPort(EmbeddedKafkaConfig()) { config =>
+      {
+
+        val destinationTopic = "destination"
+
+        val producerSettings = ProducerSettings(
+          Map(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:${config.kafkaPort}",
+            ProducerConfig.ACKS_CONFIG -> "all",
+            ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION -> "1"
+          )
+        )
+
+        val start = System.currentTimeMillis()
+        producerStream[IO](producerSettings, stringSerializer, stringSerializer)
+          .flatMap { producer =>
+            Stream
+              .iterate(0)(_ + 1)
+              .segmentN(100)
+              .flatMap(Stream.segment)
+              .evalMap[IO, IO[RecordMetadata]] { i =>
+                val record =
+                  new ProducerRecord[String, String](destinationTopic,
+                                                     s"key-$i",
+                                                     s"value-$i")
+                produceRecordWithBatching[IO].apply(producer, record)
+              }
+              // The buffer allow to put 1000 elements in the batch before waiting for the callback
+              .buffer(1000)
+              .evalMap(identity)
+              .take(100000)
+          }
+          .compile
+          .toVector
+          .unsafeRunSync()
+
+        println(System.currentTimeMillis() - start)
+
+        val messages =
+          consumeNumberKeyedMessagesFrom[String, String](destinationTopic,
+                                                         1000,
+                                                         false)
+
+        messages should not be empty
+      }
     }
   }
 


### PR DESCRIPTION
Add produceRecordWithBatching that allows the Kafka producer to optimize by sending batches of events.

I did not find a way to test it beside enable the log and observe that the producer sends records in batch.