### PR TITLE
Preserving message on produce errors

### DIFF
--- a/src/main/scala/com/ovoenergy/fs2/kafka/KafkaProduceError.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/KafkaProduceError.scala
@@ -1,0 +1,7 @@
+package com.ovoenergy.fs2.kafka
+
+import org.apache.kafka.clients.producer.ProducerRecord
+
+final case class KafkaProduceError[K, V](record: ProducerRecord[K, V],
+                                         error: Throwable)
+    extends Throwable(error)

--- a/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
@@ -4,6 +4,7 @@ import cats.effect.{Async, Sync}
 import cats.syntax.traverse._
 import com.ovoenergy.fs2.kafka.Producing._
 import fs2._
+import fs2.async.mutable.Topic
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.serialization.Serializer
 
@@ -41,6 +42,12 @@ trait Producing {
     */
   def produceRecordBatch[F[_]]: ProduceRecordBatchPartiallyApplied[F] =
     new ProduceRecordBatchPartiallyApplied[F]()
+
+  /**
+    * Sends items, communicated through `fs2.Topic` as ProducerRecord[K,V] to Kafka.
+    */
+  def subscribedProduce[F[_]]: SubscribedProducePurtiallyApplied[F] =
+    new SubscribedProducePurtiallyApplied[F]
 
 }
 
@@ -136,6 +143,19 @@ object Producing {
         }
       })
     }
+  }
+
+  private[kafka] final class SubscribedProducePurtiallyApplied[F[_]] {
+    def apply[K, V, B](
+        p: Producer[K, V],
+        topic: Topic[F, B],
+        transformer: Pipe[F, B, ProducerRecord[K, V]],
+        maxQueueSize: Int = 500
+    )(implicit F: Async[F]): Stream[F, RecordMetadata] =
+      topic
+        .subscribe(maxQueueSize)
+        .through(transformer)
+        .evalMap(pr => produceRecord(p, pr))
   }
 
   private def initProducer[F[_]: Sync, K, V](

--- a/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
@@ -103,7 +103,7 @@ object Producing {
           record,
           (metadata: RecordMetadata, exception: Exception) =>
             Option(exception) match {
-              case Some(e) => cb(Left(e))
+              case Some(e) => cb(Left(KafkaProduceError(record, e)))
               case None    => cb(Right(metadata))
           }
         )
@@ -129,8 +129,9 @@ object Producing {
               record,
               (metadata: RecordMetadata, exception: Exception) =>
                 Option(exception) match {
-                  case Some(e) => promise.complete(Failure(e)); ()
-                  case None    => promise.complete(Success((metadata, p))); ()
+                  case Some(e) =>
+                    promise.complete(Failure(KafkaProduceError(record, e))); ()
+                  case None => promise.complete(Success((metadata, p))); ()
               }
             )
 


### PR DESCRIPTION
Hi. Since producer can throw, i would like to keep the record for some recovery procedure.
The idea is that i can add .attempt after producing stream , and recover failed messages.