### PR TITLE
Keeping record when producer fails

### DIFF
--- a/src/main/scala/com/ovoenergy/fs2/kafka/KafkaProduceError.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/KafkaProduceError.scala
@@ -1,7 +1,0 @@
-package com.ovoenergy.fs2.kafka
-
-import org.apache.kafka.clients.producer.ProducerRecord
-
-final case class KafkaProduceError[K, V](record: ProducerRecord[K, V],
-                                         error: Throwable)
-    extends Throwable(error)

--- a/src/main/scala/com/ovoenergy/fs2/kafka/KafkaProduceError.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/KafkaProduceError.scala
@@ -1,0 +1,7 @@
+package com.ovoenergy.fs2.kafka
+
+import org.apache.kafka.clients.producer.ProducerRecord
+
+final case class KafkaProduceError[K, V](record: ProducerRecord[K, V],
+                                         error: Throwable)
+    extends Throwable(error)

--- a/src/main/scala/com/ovoenergy/fs2/kafka/KafkaProduceException.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/KafkaProduceException.scala
@@ -1,0 +1,7 @@
+package com.ovoenergy.fs2.kafka
+
+import org.apache.kafka.clients.producer.ProducerRecord
+
+final case class KafkaProduceException[K, V](record: ProducerRecord[K, V],
+                                             cause: Throwable)
+    extends Exception(cause)

--- a/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
@@ -96,7 +96,7 @@ object Producing {
           record,
           (metadata: RecordMetadata, exception: Exception) =>
             Option(exception) match {
-              case Some(e) => cb(Left(KafkaProduceError(record, e)))
+              case Some(e) => cb(Left(KafkaProduceException(record, e)))
               case None    => cb(Right(metadata))
           }
         )
@@ -123,7 +123,8 @@ object Producing {
               (metadata: RecordMetadata, exception: Exception) =>
                 Option(exception) match {
                   case Some(e) =>
-                    promise.complete(Failure(KafkaProduceError(record, e))); ()
+                    promise.complete(Failure(KafkaProduceException(record, e)));
+                    ()
                   case None => promise.complete(Success((metadata, p))); ()
               }
             )

--- a/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
@@ -96,7 +96,7 @@ object Producing {
           record,
           (metadata: RecordMetadata, exception: Exception) =>
             Option(exception) match {
-              case Some(e) => cb(Left(e))
+              case Some(e) => cb(Left(KafkaProduceError(record, e)))
               case None    => cb(Right(metadata))
           }
         )
@@ -122,8 +122,9 @@ object Producing {
               record,
               (metadata: RecordMetadata, exception: Exception) =>
                 Option(exception) match {
-                  case Some(e) => promise.complete(Failure(e)); ()
-                  case None    => promise.complete(Success((metadata, p))); ()
+                  case Some(e) =>
+                    promise.complete(Failure(KafkaProduceError(record, e))); ()
+                  case None => promise.complete(Success((metadata, p))); ()
               }
             )
 

--- a/src/test/scala/com/ovoenergy/fs2/kafka/KafkaSpec.scala
+++ b/src/test/scala/com/ovoenergy/fs2/kafka/KafkaSpec.scala
@@ -356,6 +356,31 @@ class KafkaSpec extends BaseUnitSpec with EmbeddedKafka {
       }
 
     }
+
+    "throw exception when failing to communicate with kafka" in {
+      import cats.syntax.all._
+      import scala.concurrent.ExecutionContext.Implicits.global
+
+      val producer = new MockProducer[String, String](false,
+                                                      new StringSerializer,
+                                                      new StringSerializer)
+      val error = new RuntimeException("error")
+      val errorEmiter =
+        fs2.Stream.eval(IO(Thread.sleep(300)) *> IO(producer.errorNext(error)))
+      val record = new ProducerRecord[String, String]("topic", "foo", "bar")
+
+      val kafkaStream = fs2.Stream.eval(produceRecord[IO](producer, record))
+
+      val exception = the[KafkaProduceError[String, String]] thrownBy kafkaStream
+        .concurrently(errorEmiter)
+        .compile
+        .toList
+        .unsafeRunSync()
+      exception.record shouldBe record
+      exception.error shouldBe error
+
+    }
+
   }
 
   "produceRecordBatch" should {

--- a/src/test/scala/com/ovoenergy/fs2/kafka/KafkaSpec.scala
+++ b/src/test/scala/com/ovoenergy/fs2/kafka/KafkaSpec.scala
@@ -11,6 +11,7 @@ import org.apache.kafka.clients.consumer.{
   KafkaConsumer
 }
 import org.apache.kafka.clients.producer.{
+  MockProducer,
   ProducerConfig,
   ProducerRecord,
   RecordMetadata
@@ -371,13 +372,13 @@ class KafkaSpec extends BaseUnitSpec with EmbeddedKafka {
 
       val kafkaStream = fs2.Stream.eval(produceRecord[IO](producer, record))
 
-      val exception = the[KafkaProduceError[String, String]] thrownBy kafkaStream
+      val exception = the[KafkaProduceException[String, String]] thrownBy kafkaStream
         .concurrently(errorEmiter)
         .compile
         .toList
         .unsafeRunSync()
       exception.record shouldBe record
-      exception.error shouldBe error
+      exception.cause shouldBe error
 
     }
 


### PR DESCRIPTION
Hi. Since producer can throw, i would like to keep the record for some recovery procedure.
The idea is that i can add `.attempt` after producing stream , and recover failed messages.