### PR TITLE
update fs2 version to 1.0.0-M5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4"
 
   object fs2 {
-    private val version = "1.0.0-M3"
+    private val version = "1.0.0-M5"
 
     lazy val core = "co.fs2" %% "fs2-core" % version
     lazy val io = "co.fs2" %% "fs2-io" % version

--- a/src/main/scala/com/ovoenergy/fs2/kafka/ProducerSyntax.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/ProducerSyntax.scala
@@ -1,7 +1,7 @@
 package com.ovoenergy.fs2.kafka
 
 import cats.effect.{Async, Sync, Concurrent}
-import fs2._, async.mutable.Topic
+import fs2._, concurrent.Topic
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.serialization.Serializer
 

--- a/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
+++ b/src/main/scala/com/ovoenergy/fs2/kafka/Producing.scala
@@ -5,7 +5,7 @@ import cats.effect.implicits._
 import cats.syntax.traverse._
 import cats.syntax.functor._
 import cats.syntax.either._
-import fs2._, async.mutable.Topic
+import fs2._, concurrent.Topic
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.serialization.Serializer
 

--- a/src/test/scala/com/ovoenergy/fs2/kafka/KafkaSpec.scala
+++ b/src/test/scala/com/ovoenergy/fs2/kafka/KafkaSpec.scala
@@ -20,10 +20,11 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization._
 
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
 
 class KafkaSpec extends BaseUnitSpec with EmbeddedKafka {
+
+  implicit val ec = cats.effect.internals.IOContextShift.global
 
   implicit val stringSerializer: Serializer[String] = new StringSerializer
   implicit val stringDeserializer: Deserializer[String] = new StringDeserializer
@@ -360,7 +361,6 @@ class KafkaSpec extends BaseUnitSpec with EmbeddedKafka {
 
     "throw exception when failing to communicate with kafka" in {
       import cats.syntax.all._
-      import scala.concurrent.ExecutionContext.Implicits.global
 
       val producer = new MockProducer[String, String](false,
                                                       new StringSerializer,
@@ -504,7 +504,7 @@ class KafkaSpec extends BaseUnitSpec with EmbeddedKafka {
   "subscrubedProduce" should {
     "produce transformed messages upon events in fs2.Topic" in {
 
-      val topic = fs2.async.topic[IO, Int](0).unsafeRunSync()
+      val topic = fs2.concurrent.Topic[IO, Int](0).unsafeRunSync()
 
       val publisherStream = fs2.Stream.eval(topic.publish1(1))
 


### PR DESCRIPTION
Updated fs2 to 1.0.0-M5 to have stable cats-effect 1.0.0. See #17

It would be really great to have a patch release to avoid binary incompatibility issues with the latest fs2.